### PR TITLE
[Weekand-1014] Button 컴포넌트 rest props를 받을 수 있는 형태로 수정

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,13 +1,13 @@
-import { ComponentProps } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 import styled from 'styled-components';
 
-interface ButtonProps extends ComponentProps<'button'> {
+interface ButtonProps extends ComponentPropsWithoutRef<'button'> {
   onClick: () => void;
 }
 
-export const Button = ({ children, onClick, type = 'button' }: ButtonProps) => {
+export const Button = ({ children, onClick, type = 'button', ...restProps }: ButtonProps) => {
   return (
-    <StyledButton type={type} onClick={onClick}>
+    <StyledButton type={type} onClick={onClick} {...restProps}>
       {children}
     </StyledButton>
   );


### PR DESCRIPTION
### 🔐 우리를 위해 꼭 지켜주세요

- 이곳에 작성되는 모든 글들은 프로젝트 히스토리를 모르는 사람이 와서 읽었을 때 이해할 수 있을 정도로 구체적이어야 합니다.

- 커밋을 작고 명확하게 구분해주세요.

- PR의 크기를 최대한 작게 유지해주세요! (변경되는 라인이 1000줄이 넘어서는 안됩니다.)

- Approve를 확인하고 merge해주세요. 의견을 남기셨다면 해당 의견에 대한 논의, 반영이 완료된 이후에 approve 해주셔야 합니다.

- 이해하지 못한 부분이 있다면 추가 설명을 요청해주세요.

---

### ✏️ 어떠한 기능이 추가되었나요

- [x] button 컴포넌트에 rest props를 받을 수 있는 형태로 작성

---

### ❗ 새롭게 알게된 점

`ComponentProps`를 사용하니까 에러가 났습니다. ref에 대한 대응이 없었기 때문이었는데 이를 통해 `ComponentWithoutRef`와 `ComponentWithRef`라는 헬퍼 함수들을 알게 되었습니다.

---

### ❓ 고민중인 부분



---

### 📖 참고문헌

https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/
