### PR TITLE
[Weekand-1035] JobSelection 컴포넌트 디자인에 맞게 수정

### DIFF
--- a/src/components/common/Interest.tsx
+++ b/src/components/common/Interest.tsx
@@ -1,13 +1,13 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import styled from 'styled-components';
 
-interface JobSelectionProps {
+interface InterestProps {
   name: string;
   totalChoices: string[];
   setTotalChoices: Dispatch<SetStateAction<string[]>>;
 }
 
-export const JobSelection = ({ name, totalChoices, setTotalChoices }: JobSelectionProps) => {
+export const Interest = ({ name, totalChoices, setTotalChoices }: InterestProps) => {
   const [isClicked, setIsClicked] = useState(false);
 
   const onClick = () => {

--- a/src/components/common/Interest.tsx
+++ b/src/components/common/Interest.tsx
@@ -32,17 +32,21 @@ export const Interest = ({ name, totalChoices, setTotalChoices }: InterestProps)
 };
 
 const Selected = styled.button`
-  background-color: #00f;
-  border: 1px solid #00f;
-  color: #fff;
-  padding: 10px 20px;
-  border-radius: 20px;
+  background-color: ${({ theme: { colors } }) => colors.WeekandBlueSub};
+  color: ${({ theme: { colors } }) => colors.WeekandBlue};
+  padding: 8px 16px;
+  border-radius: 108px;
+  margin: 0px 5px;
+  font-size: 16px;
+  font-weight: 700;
 `;
 
 const NotSelected = styled.button`
-  background-color: #fff;
-  border: 1px solid #00f;
-  color: #00f;
-  padding: 10px 20px;
-  border-radius: 20px;
+  background-color: ${({ theme: { colors } }) => colors.Gray100};
+  color: ${({ theme: { colors } }) => colors.Gray400};
+  padding: 8px 16px;
+  border-radius: 108px;
+  margin: 0px 5px;
+  font-size: 16px;
+  font-weight: 500;
 `;

--- a/src/components/common/JobSelection.tsx
+++ b/src/components/common/JobSelection.tsx
@@ -1,14 +1,22 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import styled from 'styled-components';
 
 interface JobSelectionProps {
   name: string;
-  isClicked: boolean;
-  setIsClicked: Dispatch<SetStateAction<boolean>>;
+  totalChoices: string[];
+  setTotalChoices: Dispatch<SetStateAction<string[]>>;
 }
 
-export const JobSelection = ({ name, isClicked, setIsClicked }: JobSelectionProps) => {
+export const JobSelection = ({ name, totalChoices, setTotalChoices }: JobSelectionProps) => {
+  const [isClicked, setIsClicked] = useState(false);
+
   const onClick = () => {
+    if (isClicked) {
+      const exceptClickedName = totalChoices.filter((totalChoice) => totalChoice !== name);
+      setTotalChoices(exceptClickedName);
+    } else {
+      setTotalChoices([...totalChoices, name]);
+    }
     setIsClicked(!isClicked);
   };
 


### PR DESCRIPTION
### 🔐 우리를 위해 꼭 지켜주세요

- 이곳에 작성되는 모든 글들은 프로젝트 히스토리를 모르는 사람이 와서 읽었을 때 이해할 수 있을 정도로 구체적이어야 합니다.

- 커밋을 작고 명확하게 구분해주세요.

- PR의 크기를 최대한 작게 유지해주세요! (변경되는 라인이 1000줄이 넘어서는 안됩니다.)

- Approve를 확인하고 merge해주세요. 의견을 남기셨다면 해당 의견에 대한 논의, 반영이 완료된 이후에 approve 해주셔야 합니다.

- 이해하지 못한 부분이 있다면 추가 설명을 요청해주세요.

---

### ✏️ 어떠한 기능이 추가되었나요

- [x] JobSelection 컴포넌트 적용 방법 수정

저희가 기획한 대로 특정 배열에 클릭된 모든 요소를 저장하는 형태로 해당 컴포넌트 클릭 시 추가되도록 수정했습니다.

- [x] 디자인에 맞게 컴포넌트 수정

클릭 전

<img width="64" alt="스크린샷 2022-06-08 오후 10 54 44" src="https://user-images.githubusercontent.com/72953316/172634416-65b8fc83-9e72-4324-8f48-45311dece51d.png">

클릭 후

<img width="69" alt="스크린샷 2022-06-08 오후 10 55 13" src="https://user-images.githubusercontent.com/72953316/172634543-00b27aff-e391-4f4c-9b2d-292ec90d1f53.png">

- [x] 컴포넌트 JobSelection -> Interest로 수정

해당 컴포넌트가 관심사의 특정 요소를 고를 때 사용되는 컴포넌트이기에 Interest가 가독성이 더 좋다고 느껴서 네이밍을 수정했습니다.

---

### ❗ 새롭게 알게된 점



---

### ❓ 고민중인 부분



---

### 📖 참고문헌


