### PR TITLE
[Weekand-1040] 보여지는 팝업 요소 context로 전환되게 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => {
           path="/"
           element={
             <Suspense fallback={<>Loading...</>}>
-              <Home />
+              <Login />
             </Suspense>
           }
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => {
           path="/"
           element={
             <Suspense fallback={<>Loading...</>}>
-              <Login />
+              <Home />
             </Suspense>
           }
         />

--- a/src/components/common/CalendarPopUp.tsx
+++ b/src/components/common/CalendarPopUp.tsx
@@ -1,13 +1,19 @@
 import { useContext } from 'react';
 
-import { PopUpContext } from '@/contexts';
+import { DimmedLayerContext, PopUpContext } from '@/contexts';
 
 export const CalendarPopUp = () => {
-  const { isCalendarOpen, setIsCalendarOpen } = useContext(PopUpContext);
+  const { setIsVisible: setPopUpVisible } = useContext(PopUpContext);
+  const { setIsVisible: setDimmedVisible } = useContext(DimmedLayerContext);
+
+  const onClick = () => {
+    setPopUpVisible(false);
+    setDimmedVisible(false);
+  };
 
   return (
     <>
-      <button onClick={() => setIsCalendarOpen(!isCalendarOpen)}>Close PopUp</button>
+      <button onClick={onClick}>Close PopUp</button>
       <h1>Calendar</h1>
       <p>화려한 달력이 있을 예정....</p>
     </>

--- a/src/components/common/FindPasswordPopUp.tsx
+++ b/src/components/common/FindPasswordPopUp.tsx
@@ -1,13 +1,19 @@
 import { useContext } from 'react';
 
-import { PopUpContext } from '@/contexts';
+import { DimmedLayerContext, PopUpContext } from '@/contexts';
 
 export const FindPasswordPopUp = () => {
-  const { isFindPasswordOpen, setIsFindPasswordOpen } = useContext(PopUpContext);
+  const { setIsVisible: setPopUpVisible } = useContext(PopUpContext);
+  const { setIsVisible: setDimmedVisible } = useContext(DimmedLayerContext);
+
+  const onClick = () => {
+    setPopUpVisible(false);
+    setDimmedVisible(false);
+  };
 
   return (
     <>
-      <button onClick={() => setIsFindPasswordOpen(!isFindPasswordOpen)}>Close PopUp</button>
+      <button onClick={onClick}>Close PopUp</button>
       <h1>Find Password</h1>
       <p>임시 비밀번호 발급...</p>
     </>

--- a/src/components/common/PopUp.tsx
+++ b/src/components/common/PopUp.tsx
@@ -1,11 +1,10 @@
 import { useContext } from 'react';
 import styled from 'styled-components';
 
-import { CalendarPopUp, FindPasswordPopUp } from '@/components';
 import { PopUpContext } from '@/contexts';
 
 export const PopUp = () => {
-  const { isCalendarOpen, isFindPasswordOpen, isVisible, innerContent } = useContext(PopUpContext);
+  const { isVisible, innerContent } = useContext(PopUpContext);
 
   return (
     <div>

--- a/src/components/common/PopUp.tsx
+++ b/src/components/common/PopUp.tsx
@@ -5,14 +5,11 @@ import { CalendarPopUp, FindPasswordPopUp } from '@/components';
 import { PopUpContext } from '@/contexts';
 
 export const PopUp = () => {
-  const { isCalendarOpen, isFindPasswordOpen, isVisible } = useContext(PopUpContext);
+  const { isCalendarOpen, isFindPasswordOpen, isVisible, innerContent } = useContext(PopUpContext);
 
   return (
     <div>
-      <PopUpWrapper visible={isVisible}>
-        {isCalendarOpen && <CalendarPopUp />}
-        {isFindPasswordOpen && <FindPasswordPopUp />}
-      </PopUpWrapper>
+      <PopUpWrapper visible={isVisible}>{innerContent}</PopUpWrapper>
     </div>
   );
 };

--- a/src/contexts/PopUpContext.tsx
+++ b/src/contexts/PopUpContext.tsx
@@ -1,4 +1,11 @@
-import { createContext, Dispatch, PropsWithChildren, SetStateAction, useState } from 'react';
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  ReactNode,
+  SetStateAction,
+  useState,
+} from 'react';
 
 type PopUpProps = {
   isVisible: boolean;
@@ -7,6 +14,8 @@ type PopUpProps = {
   setIsCalendarOpen: Dispatch<SetStateAction<boolean>>;
   isFindPasswordOpen: boolean;
   setIsFindPasswordOpen: Dispatch<SetStateAction<boolean>>;
+  innerContent: ReactNode;
+  setInnerContent: Dispatch<SetStateAction<ReactNode>>;
 };
 
 export const PopUpContext = createContext<PopUpProps>({} as PopUpProps);
@@ -15,6 +24,7 @@ export const PopUpContextProvider = ({ children }: PropsWithChildren<unknown>) =
   const [isVisible, setIsVisible] = useState(false);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [isFindPasswordOpen, setIsFindPasswordOpen] = useState(false);
+  const [innerContent, setInnerContent] = useState<ReactNode>();
 
   return (
     <PopUpContext.Provider
@@ -25,6 +35,8 @@ export const PopUpContextProvider = ({ children }: PropsWithChildren<unknown>) =
         setIsCalendarOpen,
         isFindPasswordOpen,
         setIsFindPasswordOpen,
+        innerContent,
+        setInnerContent,
       }}
     >
       {children}

--- a/src/contexts/PopUpContext.tsx
+++ b/src/contexts/PopUpContext.tsx
@@ -10,10 +10,6 @@ import {
 type PopUpProps = {
   isVisible: boolean;
   setIsVisible: Dispatch<SetStateAction<boolean>>;
-  isCalendarOpen: boolean;
-  setIsCalendarOpen: Dispatch<SetStateAction<boolean>>;
-  isFindPasswordOpen: boolean;
-  setIsFindPasswordOpen: Dispatch<SetStateAction<boolean>>;
   innerContent: ReactNode;
   setInnerContent: Dispatch<SetStateAction<ReactNode>>;
 };
@@ -22,8 +18,6 @@ export const PopUpContext = createContext<PopUpProps>({} as PopUpProps);
 
 export const PopUpContextProvider = ({ children }: PropsWithChildren<unknown>) => {
   const [isVisible, setIsVisible] = useState(false);
-  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
-  const [isFindPasswordOpen, setIsFindPasswordOpen] = useState(false);
   const [innerContent, setInnerContent] = useState<ReactNode>();
 
   return (
@@ -31,10 +25,6 @@ export const PopUpContextProvider = ({ children }: PropsWithChildren<unknown>) =
       value={{
         isVisible,
         setIsVisible,
-        isCalendarOpen,
-        setIsCalendarOpen,
-        isFindPasswordOpen,
-        setIsFindPasswordOpen,
         innerContent,
         setInnerContent,
       }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from 'styled-components';
 import { ApolloProvider, ApolloClient, InMemoryCache } from '@apollo/client';
 
 import App from './App';
-import { PopUpContextProvider } from '@/contexts';
+import { DimmedLayerContextProvider, PopUpContextProvider } from '@/contexts';
 import { AppProvider } from '@/utils';
 import { GlobalStyle, theme } from '@/style';
 
@@ -22,7 +22,7 @@ const client = new ApolloClient({
 
 root.render(
   <ApolloProvider client={client}>
-    <AppProvider components={[PopUpContextProvider]}>
+    <AppProvider components={[DimmedLayerContextProvider, PopUpContextProvider]}>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
         <App />


### PR DESCRIPTION
### 🔐 우리를 위해 꼭 지켜주세요

- 이곳에 작성되는 모든 글들은 프로젝트 히스토리를 모르는 사람이 와서 읽었을 때 이해할 수 있을 정도로 구체적이어야 합니다.

- 커밋을 작고 명확하게 구분해주세요.

- PR의 크기를 최대한 작게 유지해주세요! (변경되는 라인이 1000줄이 넘어서는 안됩니다.)

- Approve를 확인하고 merge해주세요. 의견을 남기셨다면 해당 의견에 대한 논의, 반영이 완료된 이후에 approve 해주셔야 합니다.

- 이해하지 못한 부분이 있다면 추가 설명을 요청해주세요.

---

### ✏️ 어떠한 기능이 추가되었나요

- [x] 팝업 사용 방법 수정

<img width="744" alt="스크린샷 2022-06-13 오전 12 28 47" src="https://user-images.githubusercontent.com/72953316/173241122-2112a7fa-a9ec-46b0-9f63-68e54c21c199.png">

- 원하는 팝업을 전달하지 않고 조건에 따라 전환하는 방법에서, 원하는 팝업을 직접 전달하는 형태로 수정하였습니다.

> 추가되는 요소는 다음과 같습니다.
> - setInnerContent : 팝업으로 보여지는 컴포넌트 변경
> - setPopUpVisible : 팝업을 보여주는 요소
> - setDimmedVisible : 딤드레이어를 보여주는 요소

---

### ❗ 새롭게 알게된 점



---

### ❓ 고민중인 부분



---

### 📖 참고문헌


