### PR TITLE
[Weekand-1059] 메인 페이지 - 개인 프로필 컴포넌트

### DIFF
--- a/src/pages/home/components/Profile.tsx
+++ b/src/pages/home/components/Profile.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+export const Profile = () => {
+  return (
+    <Wrapper>
+      <Informations>
+        <Name>본입입니다</Name>
+        <Email>thd6576@naver.com</Email>
+      </Informations>
+      <ImageWrapper>
+        <img src="" alt="" width={80} height={80} />
+      </ImageWrapper>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  padding: 31px 0;
+
+  &:after {
+    ${({ theme: { clearFloat } }) => clearFloat}
+  }
+`;
+
+const Informations = styled.div`
+  float: left;
+`;
+
+const Name = styled.div`
+  ${({ theme: { fonts } }) => fonts.Head1};
+  margin-bottom: 16px;
+  width: 310px;
+`;
+
+const Email = styled.span`
+  ${({ theme: { fonts } }) => fonts.Body1('Gray500')};
+`;
+
+const ImageWrapper = styled.div`
+  float: right;
+  background-color: ${({ theme: { colors } }) => colors.Gray300};
+  border-radius: 24px;
+`;

--- a/src/pages/home/components/index.ts
+++ b/src/pages/home/components/index.ts
@@ -2,3 +2,4 @@ export * from './FriendStories';
 export * from './FriendStory';
 export * from './Schedule';
 export * from './Schedules';
+export * from './Profile';


### PR DESCRIPTION
### 🔐 우리를 위해 꼭 지켜주세요

- 이곳에 작성되는 모든 글들은 프로젝트 히스토리를 모르는 사람이 와서 읽었을 때 이해할 수 있을 정도로 구체적이어야 합니다.

- 커밋을 작고 명확하게 구분해주세요.

- PR의 크기를 최대한 작게 유지해주세요! (변경되는 라인이 1000줄이 넘어서는 안됩니다.)

- Approve를 확인하고 merge해주세요. 의견을 남기셨다면 해당 의견에 대한 논의, 반영이 완료된 이후에 approve 해주셔야 합니다.

- 이해하지 못한 부분이 있다면 추가 설명을 요청해주세요.

---

### ✏️ 어떠한 기능이 추가되었나요

- [x] 달력 상단의 프로필을 구성합니다. 내 계정이 아닐 경우에는 이메일 대신 버튼이 나타나야 하는데 해당 부분은 api를 연동하면서 수정할 계획입니다. 요 이미지도 아마 디폴트 이미지를 쓰면 될 것 같긴 한데 확인 이후에 추가하도록 하겠습니다.
<img width="413" alt="스크린샷 2022-07-10 오후 4 30 35" src="https://user-images.githubusercontent.com/57230590/178135549-624867ae-be11-4d79-a6e2-a5417bfbe85c.png">

---

### ❗ 새롭게 알게된 점



---

### ❓ 고민중인 부분



---

### 📖 참고문헌


