### PR TITLE
[Weekand-1091] 메뉴 우클릭 시 원하는 위치에 메뉴 나오지 않는 오류

### DIFF
--- a/src/hooks/useContextMenu.tsx
+++ b/src/hooks/useContextMenu.tsx
@@ -11,10 +11,6 @@ export const useContextMenu = () => {
     event.preventDefault();
     setPointY(event.pageY);
     setShow(true);
-    if (window.innerWidth > 1120) {
-      const extraPadding = (window.innerWidth - 1120) / 2;
-      return setPointX(event.pageX - extraPadding);
-    }
     setPointX(event.pageX);
   }, []);
 

--- a/src/pages/manageCategory/components/Category.tsx
+++ b/src/pages/manageCategory/components/Category.tsx
@@ -1,21 +1,35 @@
 import { Dispatch, MouseEvent, SetStateAction } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface CategoryProps {
+  id: number;
   color: string;
   visibility: string;
   content: string;
   setIsCategoryClicked: Dispatch<SetStateAction<boolean>>;
 }
 
-export const Category = ({ color, visibility, content, setIsCategoryClicked }: CategoryProps) => {
+export const Category = ({
+  id,
+  color,
+  visibility,
+  content,
+  setIsCategoryClicked,
+}: CategoryProps) => {
+  const navigate = useNavigate();
+
+  const onClickCategory = () => {
+    navigate(`/manage-category/${id}`);
+  };
+
   const handleRightClick = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     setIsCategoryClicked(true);
   };
 
   return (
-    <Wrapper onContextMenu={handleRightClick}>
+    <Wrapper onClick={onClickCategory} onContextMenu={handleRightClick}>
       <Color color={color} />
       <Content>
         <p>{visibility}</p>
@@ -33,6 +47,7 @@ const Wrapper = styled.div`
   background-color: #fff;
   display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 const Color = styled.div<{ color: string }>`

--- a/src/pages/manageCategory/components/CategoryList.tsx
+++ b/src/pages/manageCategory/components/CategoryList.tsx
@@ -14,6 +14,7 @@ export const CategoryList = () => {
       {CATEGORIES.map((category) => (
         <Category
           key={category.id}
+          id={category.id}
           color={category.color}
           visibility={category.visible}
           content={category.content}


### PR DESCRIPTION
### 🔐 우리를 위해 꼭 지켜주세요

- 이곳에 작성되는 모든 글들은 프로젝트 히스토리를 모르는 사람이 와서 읽었을 때 이해할 수 있을 정도로 구체적이어야 합니다.

- 커밋을 작고 명확하게 구분해주세요.

- PR의 크기를 최대한 작게 유지해주세요! (변경되는 라인이 1000줄이 넘어서는 안됩니다.)

- Approve를 확인하고 merge해주세요. 의견을 남기셨다면 해당 의견에 대한 논의, 반영이 완료된 이후에 approve 해주셔야 합니다.

- 이해하지 못한 부분이 있다면 추가 설명을 요청해주세요.

---

### ✏️ 어떠한 기능이 추가되었나요

- [x] 우클릭 시 원하는 위치에 메뉴가 나오지 않는 오류 수정
- 페이지의 크기가 1120px를 넘어설 때, 정확한 위치를 측정하기 위해 제작한 로직이 오히려 사용자가 클릭한 위치를 이상한 위치로 바꾸고 있었습니다. 특정 위치를 계산하는 로직를 제거한 후, 정확한 위치에 우클릭 시 메뉴가 맞는 위치에 뜨도록 수정했습니다.

- [x] 카테고리 요소 라우팅
- 등록된 카테고리 클릭 시, 해당 세부 카테고리로 이동되지 않던 오류를 수정했습니다.


https://user-images.githubusercontent.com/72953316/179346435-ba114223-a6e3-495e-b82c-bfa2b10bc4b6.mov

---

### ❗ 새롭게 알게된 점



---

### ❓ 고민중인 부분



---

### 📖 참고문헌


